### PR TITLE
Fix bugs in get_geofabric

### DIFF
--- a/R/get_geofabric.R
+++ b/R/get_geofabric.R
@@ -44,15 +44,16 @@ get_geofabric = function(
         stop("Search in geofabric_zones for a closer match.")
       }
     }
-    large_size = grepl(pattern = "G", x = geofabric_matches$size_pbf)
-    if(interactive() & ask & large_size) {
-      message("This is a large file ", geofabric_matches$size_pbf)
-      continue = utils::menu(choices = c("Yes", "No"), title = "Would you like to download this file?")
-      if(continue != 1L) {# same reasoning as before
-        stop("Aborted by user.")
-      }
-    }
     # add would you like to proceed message?
+  }
+
+  large_size = grepl(pattern = "G", x = geofabric_matches$size_pbf)
+  if(interactive() & ask & large_size) {
+    message("This is a large file ", geofabric_matches$size_pbf)
+    continue = utils::menu(choices = c("Yes", "No"), title = "Would you like to download this file?")
+    if(continue != 1L) {# for the same reasoning as before
+      stop("Aborted by user.")
+    }
   }
 
   zone_url = geofabric_matches$pbf_url

--- a/R/get_geofabric.R
+++ b/R/get_geofabric.R
@@ -39,16 +39,16 @@ get_geofabric = function(
     high_distance = matching_dist[best_match] > max_dist
     message("No exact matching geofabric zone. Best match is ", geofabric_matches$name, " ", geofabric_matches$size_pbf)
     if(interactive() & ask & high_distance) {
-      continue = utils::menu(choices = c(TRUE, FALSE), title = "Would you like to download this file?")
-      if(continue == 2L) {# since the options are Yes/No, then No == 2L
+      continue = utils::menu(choices = c("Yes", "No"), title = "Would you like to download this file?")
+      if(continue != 1L) {# since the options are Yes/No, then Yes == 2L
         stop("Search in geofabric_zones for a closer match.")
       }
     }
     large_size = grepl(pattern = "G", x = geofabric_matches$size_pbf)
     if(interactive() & ask & large_size) {
       message("This is a large file ", geofabric_matches$size_pbf)
-      continue = utils::menu(choices = c(TRUE, FALSE), title = "Would you like to download this file?")
-      if(continue == 2L) {# same reasoning as before
+      continue = utils::menu(choices = c("Yes", "No"), title = "Would you like to download this file?")
+      if(continue != 1L) {# same reasoning as before
         stop("Aborted by user.")
       }
     }

--- a/R/get_geofabric.R
+++ b/R/get_geofabric.R
@@ -40,7 +40,7 @@ get_geofabric = function(
     message("No exact matching geofabric zone. Best match is ", geofabric_matches$name, " ", geofabric_matches$size_pbf)
     if(interactive() & ask & high_distance) {
       continue = utils::menu(choices = c(TRUE, FALSE), title = "Would you like to download this file?")
-      if(!continue) {
+      if(continue == 2L) {# since the options are Yes/No, then No == 2L
         stop("Search in geofabric_zones for a closer match.")
       }
     }
@@ -48,7 +48,7 @@ get_geofabric = function(
     if(interactive() & ask & high_distance) {
       message("This is a large file ", geofabric_matches$size_pbf)
       continue = utils::menu(choices = c(TRUE, FALSE), title = "Would you like to download this file?")
-      if(!continue) {
+      if(continue == 2L) {# same reasoning as before
         stop("Aborted by user.")
       }
     }

--- a/R/get_geofabric.R
+++ b/R/get_geofabric.R
@@ -45,7 +45,7 @@ get_geofabric = function(
       }
     }
     large_size = grepl(pattern = "G", x = geofabric_matches$size_pbf)
-    if(interactive() & ask & high_distance) {
+    if(interactive() & ask & large_size) {
       message("This is a large file ", geofabric_matches$size_pbf)
       continue = utils::menu(choices = c(TRUE, FALSE), title = "Would you like to download this file?")
       if(continue == 2L) {# same reasoning as before


### PR DESCRIPTION
The first and third commit corrects a bug in `if(!continue)` since the output of `utils::menu` is not a logical value (i.e. TRUE or FALSE, the choices) but "The number corresponding to the selected item, or 0 if no choice was made." This means that we can substitute TRUE/FALSE with "Yes"/"No" and check if the user selectes "yes" (which corresponds to the value 1). I choose to modify the if clause to `if(continue != 1L)` since it now considers also the case in which the user entered 0 to `utils::menu` (i.e. no choice). 

The second and fourth commit correct a typo into the large_size check and a bug since we cannot put the large_size check inside the if (nrow(...) == 0) otherwise if it finds a match (e.g. get_geofabric("Africa") it doesn't check for large_size. 

I think you can check that now everthing works with this example: 

``` r
get_geofabric("HFIL")
```